### PR TITLE
Support in memory markdown files

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -15,107 +16,20 @@ import (
 	"strings"
 
 	"github.com/davinche/godown/markdown"
+	"github.com/davinche/godown/memory"
 	"github.com/davinche/godown/server"
+	"github.com/davinche/godown/subscribe"
 	"github.com/davinche/godown/watcher"
 	"github.com/kardianos/osext"
 )
 
-// Helper to make an HTTP DEL request to kill the server
-func killServer(port string) (*http.Response, error) {
-	client := http.Client{}
-	req, err := http.NewRequest("DELETE", "http://localhost:"+port, nil)
-	if err != nil {
-		return nil, err
-	}
-	return client.Do(req)
-}
-
-func killWatcher(port string, fileID string) (*http.Response, error) {
-	client := http.Client{}
-	req, err := http.NewRequest("DELETE", "http://localhost:"+port+"?id="+fileID, nil)
-	if err != nil {
-		return nil, err
-	}
-	return client.Do(req)
-}
-
-// Helper to add a new file to be watched on an existing server
-func addFile(port string, f *markdown.File) (*http.Response, error) {
-	watchRequest := watcher.WatchFileRequest{File: f.Path}
-	marshalled, err := json.Marshal(watchRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	client := http.Client{}
-	req, err := http.NewRequest("POST", "http://localhost:"+port, bytes.NewBuffer(marshalled))
-	if err != nil {
-		return nil, err
-	}
-	return client.Do(req)
-}
-
-func launchBrowser(browser string, port string, file *markdown.File) {
-	// Launch the browser
-	var args []string
-	if browser == "" {
-		switch runtime.GOOS {
-		case "darwin":
-			args = append(args, "open", "-g")
-			break
-		case "linux":
-			args = append(args, "xdg-open")
-			break
-		case "windows":
-			args = append(args, "cmd", "/C", "start", "/B")
-			break
-		}
-	} else {
-		args = append(args, browser)
-	}
-
-	if len(args) == 0 {
-		fmt.Println("warning: no open command")
-	} else {
-		args = append(args, "http://localhost:"+port+"?id="+file.ID)
-		command := exec.Command(args[0], args[1:]...)
-		err := command.Start()
-		if err != nil {
-			fmt.Printf("error: could not open url: %v\n", err)
-		}
-	}
-}
-
-func listenAndServe(port string, f *markdown.File, done chan struct{}) {
-	// try to listen from the port
-	err := http.ListenAndServe(":"+port, nil)
-	if err != nil {
-		fmt.Printf("error: could not start server; trying to add to existing server: %q\n", err)
-		req, err := addFile(port, f)
-		if err != nil || req.StatusCode != http.StatusOK {
-			fmt.Printf("error: could not register file to watch with server: %q\n", err)
-		}
-		done <- struct{}{}
-	}
-}
-
-func help() {
-	fmt.Fprintln(os.Stdout, "usage: godown {FLAGS} [COMMANDS] <PATH>\n")
-	fmt.Fprintln(os.Stdout, "  Watches a markdown file for changes and previews it in the browser.\n")
-	fmt.Fprintln(os.Stdout, "FLAGS:\n")
-	flag.PrintDefaults()
-	fmt.Fprintln(os.Stdout, "\nCOMMANDS:\n")
-	fmt.Fprintln(os.Stdout, "  start <PATH>")
-	fmt.Fprintf(os.Stdout, "        %s\n", "Starts watching a file given a path.")
-	fmt.Fprintln(os.Stdout, "  stop <PATH>")
-	fmt.Fprintf(os.Stdout, "        %s\n", "*optional* path: Stops watching a file if a path is given, otherwise stops the Godown daemon.")
-}
-
 func main() {
 	// Args
-	port := flag.Int("p", 1337, "GoDown Port")
-	browser := flag.String("b", "", "Browser to preview with")
+	port := flag.Int("p", 1337, "Port")
+	browser := flag.String("b", "", "Specify the browser to preview with.")
+	shouldLaunch := flag.Bool("l", false, "Open the preview in a browser.")
 	flag.Parse()
+
 	strPort := strconv.Itoa(*port)
 	doneCh := make(chan struct{})
 
@@ -125,43 +39,25 @@ func main() {
 	}
 
 	command := strings.ToLower(flag.Arg(0))
-	if command != "start" && command != "stop" {
+	if command != "start" && command != "stop" && command != "send" {
 		help()
 		return
 	}
 
-	file := flag.Arg(1)
+	// ------------------------------------------------------------------------
+	// Parse the Command ------------------------------------------------------
+	// ------------------------------------------------------------------------
+
 	// stop command issued: send a stop request to the server
 	if command == "stop" {
 		fmt.Println("stopping")
-		if file != "" {
-			markdownFile, err := markdown.NewFile(file)
-			fmt.Println("stopping file " + markdownFile.Path)
-			if err != nil {
-				fmt.Printf("error: could not obtain markdown file: %q\n", err)
-				return
-			}
-			if _, err = killWatcher(strPort, markdownFile.ID); err != nil {
-				fmt.Printf("error: could not create stop file watcher: %q\n", err)
-			}
-			return
-		}
-
-		if _, err := killServer(strPort); err != nil {
-			fmt.Printf("error: could not create stop server request: %q\n", err)
-			return
-		}
-	}
-
-	// start command
-	if file == "" {
-		help()
+		stop(flag.Arg(1), strPort)
 		return
 	}
 
-	markdownFile, err := markdown.NewFile(file)
-	if err != nil {
-		fmt.Printf("error: could not obtain markdown file: %q\n", err)
+	// Start and Send Commands require at least 1 positional argument
+	if flag.Arg(1) == "" {
+		help()
 		return
 	}
 
@@ -171,22 +67,23 @@ func main() {
 		fmt.Println("error: could not determine binary folder")
 		os.Exit(1)
 	}
-	fmt.Println(binDir)
 	templates := template.Must(template.ParseFiles(binDir + "/index.html"))
 
 	// ------------------------------------------------------------------------
 	// Server Registration ----------------------------------------------------
 	// ------------------------------------------------------------------------
 
-	// Watcher ----------------------------------------------------------------
+	// Watcher
 	watchMonitor := watcher.NewWatchMonitor()
-	// Websocket --------------------------------------------------------------
-	socketServer := server.NewServer(markdownFile)
+	// Websocket
+	socketServer := server.NewServer()
 	socketServer.Register("/connect")
-	// Static Files -----------------------------------------------------------
+	// Static Files
 	static := http.FileServer(http.Dir(binDir + "/static"))
-	// API --------------------------------------------------------------------
+
+	// API
 	serveRequest := func(w http.ResponseWriter, r *http.Request) {
+
 		// watch another file
 		if r.Method == "POST" {
 			defer r.Body.Close()
@@ -207,12 +104,37 @@ func main() {
 
 			// create a new watcher
 			watchMonitor.AddWatcher(markdownFile)
-			socketServer.CreateFileSubscriber(markdownFile)
+			socketServer.CreateSubscriber(markdownFile)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 
 		fID := r.URL.Query().Get("id")
+		// Add a file to memory?
+		if r.Method == "PUT" {
+			// read the body
+			defer r.Body.Close()
+			data, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("error: could not read markdown body"))
+				return
+			}
+
+			// create new inmemory markdown file
+			memoryFile, err := memory.NewFile(fID, data)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("error: could not create new in-memory markdown file"))
+				return
+			}
+
+			// create new registry
+			socketServer.CreateSubscriber(memoryFile)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
 		// shutting down the server?
 		if r.Method == "DELETE" {
 			// are we removing one file?
@@ -246,14 +168,62 @@ func main() {
 		templates.ExecuteTemplate(w, "index.html", tStruct)
 	}
 
+	// ------------------------------------------------------------------------
+	// Start Server Processes--------------------------------------------------
+	// ------------------------------------------------------------------------
 	fileChanges := make(chan *markdown.File)
-	watchMonitor.AddWatcher(markdownFile)
+	http.HandleFunc("/", serveRequest)
+	http.Handle("/static/", http.StripPrefix("/static/", static))
+	listenAndServe(strPort)
 	go watchMonitor.Start(fileChanges)
 
-	http.Handle("/static/", http.StripPrefix("/static/", static))
-	http.HandleFunc("/", serveRequest)
-	go listenAndServe(strPort, markdownFile, doneCh)
-	launchBrowser(*browser, strPort, markdownFile)
+	// START THE SERVER -------------------------------------------------------
+	if command == "start" {
+		markdownFile, err := markdown.NewFile(flag.Arg(1))
+		if err != nil {
+			fmt.Printf("error: could not obtain markdown file: %q\n", err)
+			os.Exit(1)
+			return
+		}
+		resp, err := addFile(strPort, markdownFile)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			fmt.Printf("error: could not add markdown file to the watch list: %q\n", err)
+			os.Exit(1)
+			return
+		}
+
+		if *shouldLaunch {
+			launchBrowser(*browser, strPort, markdownFile)
+		}
+	}
+
+	if command == "send" {
+		id := flag.Arg(1)
+		data := flag.Arg(2)
+		if id == "" || data == "" {
+			fmt.Println("identifier or data not specified")
+			os.Exit(1)
+			return
+		}
+
+		file, err := memory.NewFile(id, []byte(data))
+		if err != nil {
+			fmt.Printf("error: could not prepare data to send to server: %q\n", err)
+			os.Exit(1)
+			return
+		}
+
+		req, err := addData(strPort, id, file.Content)
+		if err != nil || req.StatusCode != http.StatusOK {
+			fmt.Printf("error: there was an error in the request to the server: e=%v; code=%v\n", err, req.StatusCode)
+			os.Exit(1)
+			return
+		}
+
+		if *shouldLaunch {
+			launchBrowser(*browser, strPort, file)
+		}
+	}
 
 	// Loop message from watcher
 	for {
@@ -265,4 +235,137 @@ func main() {
 			socketServer.Broadcast(changes)
 		}
 	}
+}
+
+// ----------------------------------------------------------------------------
+// Helpers --------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+
+func help() {
+	fmt.Fprintln(os.Stdout, "usage: godown {FLAGS} [COMMANDS] <PATH>\n")
+	fmt.Fprintln(os.Stdout, "  Watches a markdown file for changes and previews it in the browser.\n")
+	fmt.Fprintln(os.Stdout, "FLAGS:\n")
+	flag.PrintDefaults()
+	fmt.Fprintln(os.Stdout, "\nCOMMANDS:\n")
+	fmt.Fprintln(os.Stdout, "  start <PATH>")
+	fmt.Fprintf(os.Stdout, "        %s\n", "Starts watching a file at the given path.")
+	fmt.Fprintln(os.Stdout, "  stop <PATH>")
+	fmt.Fprintf(os.Stdout, "        %s\n", "*optional* path: "+
+		"Stops watching a file if given a path or terminates the Godown daemon.")
+	fmt.Fprintln(os.Stdout, "  send [ID] <Markdown Data>")
+	fmt.Fprintf(os.Stdout, "        %s\n", "Given an identifier and markdown data, "+
+		"send it to the daemon for rendering.")
+}
+
+// Send DELETE to server to either: stop watching a file or kill the server
+func stop(filePath string, port string) {
+	if filePath != "" {
+		fmt.Printf("stopping file %q\n", filePath)
+		markdownFile, err := markdown.NewFile(filePath)
+		if err != nil {
+			fmt.Printf("error: could not obtain markdown file: %q\n", err)
+			return
+		}
+		if _, err = killWatcher(port, markdownFile.GetID()); err != nil {
+			fmt.Printf("error: could not create stop file watcher: %q\n", err)
+		}
+		return
+	}
+
+	if _, err := killServer(port); err != nil {
+		fmt.Printf("error: could not create stop server request: %q\n", err)
+		return
+	}
+}
+
+// Start the Markdown Daemon or Issue an "ADD FILE" request
+func listenAndServe(port string) {
+	// try to listen from the port
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		fmt.Printf("error: could not start server: %q\n", err)
+		return
+	}
+	go http.Serve(listener, nil)
+}
+
+func launchBrowser(browser string, port string, file subscribe.Source) {
+	// Launch the browser
+	var args []string
+	if browser == "" {
+		switch runtime.GOOS {
+		case "darwin":
+			args = append(args, "open", "-g")
+			break
+		case "linux":
+			args = append(args, "xdg-open")
+			break
+		case "windows":
+			args = append(args, "cmd", "/C", "start", "/B")
+			break
+		}
+	} else {
+		args = append(args, browser)
+	}
+
+	if len(args) == 0 {
+		fmt.Println("warning: no open command")
+	} else {
+		args = append(args, "http://localhost:"+port+"?id="+file.GetID())
+		command := exec.Command(args[0], args[1:]...)
+		err := command.Start()
+		if err != nil {
+			fmt.Printf("error: could not open url: %v\n", err)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// HTTP API Helpers -----------------------------------------------------------
+// ----------------------------------------------------------------------------
+func addFile(port string, f *markdown.File) (*http.Response, error) {
+	watchRequest := watcher.WatchFileRequest{File: f.Path}
+	marshalled, err := json.Marshal(watchRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.Client{}
+	req, err := http.NewRequest("POST", "http://localhost:"+port, bytes.NewBuffer(marshalled))
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+func addData(port string, id string, data []byte) (*http.Response, error) {
+	client := http.Client{}
+	req, err := http.NewRequest(
+		"PUT",
+		"http://localhost:"+port+"?id="+id,
+		bytes.NewBuffer(data),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+func killServer(port string) (*http.Response, error) {
+	client := http.Client{}
+	req, err := http.NewRequest("DELETE", "http://localhost:"+port, nil)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+func killWatcher(port string, fileID string) (*http.Response, error) {
+	client := http.Client{}
+	req, err := http.NewRequest("DELETE", "http://localhost:"+port+"?id="+fileID, nil)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
 }

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -3,15 +3,19 @@ package markdown
 import (
 	"crypto/sha1"
 	"fmt"
-	"io"
 	"path/filepath"
 )
 
 // File holds the path to a file it's identifer. The identifier is used
 // to communicate to the web server which file to serve.
 type File struct {
+	id   string
 	Path string
-	ID   string
+}
+
+// GetID returns the identifier for the file
+func (f *File) GetID() string {
+	return f.id
 }
 
 // NewFile is the constructor for the object that holds the filepath
@@ -22,13 +26,9 @@ func NewFile(path string) (*File, error) {
 		return nil, err
 	}
 
-	hash := sha1.New()
-	if _, err := io.WriteString(hash, absPath); err != nil {
-		return nil, err
-	}
-	ID := fmt.Sprintf("%x", hash.Sum(nil))
+	id := fmt.Sprintf("%x", sha1.Sum([]byte(absPath)))
 	return &File{
 		Path: absPath,
-		ID:   ID,
+		id:   id,
 	}, nil
 }

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -1,0 +1,28 @@
+package memory
+
+import (
+	"crypto/sha1"
+	"fmt"
+)
+
+// File holds the path to a file it's identifer.
+type File struct {
+	id      string
+	Content []byte
+}
+
+// GetID returns the identifier for the file
+func (f *File) GetID() string {
+	return f.id
+}
+
+// NewFile is the constructor for the in-memory file
+func NewFile(id string, content []byte) (*File, error) {
+
+	hashed := fmt.Sprintf("%x", sha1.Sum([]byte(id)))
+
+	return &File{
+		id:      hashed,
+		Content: content,
+	}, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -2,97 +2,34 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"sync"
 
 	"github.com/davinche/godown/markdown"
-	"github.com/russross/blackfriday"
+	"github.com/davinche/godown/memory"
+	"github.com/davinche/godown/subscribe"
 	"golang.org/x/net/websocket"
 )
-
-// ----------------------------------------------------------------------------
-// Utility
-// ----------------------------------------------------------------------------
-type renderString struct {
-	Render string `json:"render"`
-}
-
-func getRenderedFromFile(file string) (string, error) {
-	fileStr, err := ioutil.ReadFile(file)
-	if err != nil {
-		return "", err
-	}
-	return string(blackfriday.MarkdownCommon(fileStr)), nil
-}
-
-// ----------------------------------------------------------------------------
-// Data
-// ----------------------------------------------------------------------------
-
-// track subscribers to a file
-type fileSubscribers struct {
-	file *markdown.File
-
-	clients map[*websocket.Conn]struct{}
-	sync.Mutex
-}
-
-// broadcast all changes to subscribers
-func (f *fileSubscribers) broadcast() {
-	fileStr, err := getRenderedFromFile(f.file.Path)
-	if err != nil {
-		fmt.Printf("error reading file: %q", err)
-		return
-	}
-	renderFmt := renderString{fileStr}
-	// loop and write
-	f.Lock()
-	defer f.Unlock()
-	for ws := range f.clients {
-		websocket.JSON.Send(ws, renderFmt)
-	}
-}
-
-func (f *fileSubscribers) add(ws *websocket.Conn) {
-	f.Lock()
-	defer f.Unlock()
-	f.clients[ws] = struct{}{}
-	fileStr, err := getRenderedFromFile(f.file.Path)
-	if err != nil {
-		fmt.Printf("error reading file: %q", err)
-		return
-	}
-	renderFmt := renderString{fileStr}
-	websocket.JSON.Send(ws, renderFmt)
-}
-
-func (f *fileSubscribers) del(ws *websocket.Conn) (shouldDelete bool) {
-	f.Lock()
-	defer f.Unlock()
-	delete(f.clients, ws)
-	if len(f.clients) == 0 {
-		return true
-	}
-	return false
-}
 
 // Server is a websocket server
 type Server struct {
 	prefix string
 
-	catalog map[string]*fileSubscribers
+	catalog map[string]subscribe.Handler
 	sync.Mutex
 }
 
-// CreateFileSubscriber creates a new registry for a file and it's subscribed clients
-func (s *Server) CreateFileSubscriber(file *markdown.File) {
+// CreateSubscriber creates a new registry for a file and it's subscribed clients
+func (s *Server) CreateSubscriber(source subscribe.Source) {
 	s.Lock()
 	defer s.Unlock()
-	if _, ok := s.catalog[file.ID]; !ok {
-		s.catalog[file.ID] = &fileSubscribers{
-			file:    file,
-			clients: make(map[*websocket.Conn]struct{}),
+	if _, ok := s.catalog[source.GetID()]; !ok {
+		// s.catalog[file.ID] = subscribe.NewFile(file)
+		switch source.(type) {
+		case *markdown.File:
+			s.catalog[source.GetID()] = subscribe.NewFile(source.(*markdown.File))
+		case *memory.File:
+			s.catalog[source.GetID()] = subscribe.NewMem(source.(*memory.File))
 		}
 	}
 }
@@ -133,7 +70,7 @@ func (s *Server) addClient(fileID string, ws *websocket.Conn) (success bool) {
 	if s.catalog[fileID] == nil {
 		return false
 	}
-	s.catalog[fileID].add(ws)
+	s.catalog[fileID].Add(ws)
 	return true
 }
 
@@ -143,21 +80,20 @@ func (s *Server) deleteClient(fileID string, ws *websocket.Conn) {
 	if s.catalog[fileID] == nil {
 		return
 	}
+	s.catalog[fileID].Del(ws)
 }
 
 // Broadcast to all subscribers of fileID the new file
-func (s *Server) Broadcast(file *markdown.File) {
-	fSubs := s.catalog[file.ID]
+func (s *Server) Broadcast(file subscribe.Source) {
+	fSubs := s.catalog[file.GetID()]
 	if fSubs != nil {
-		fSubs.broadcast()
+		fSubs.Broadcast()
 	}
 }
 
 // NewServer creates a new websocket server that listens to client requests
-func NewServer(f *markdown.File) *Server {
-	s := &Server{
-		catalog: make(map[string]*fileSubscribers),
+func NewServer() *Server {
+	return &Server{
+		catalog: make(map[string]subscribe.Handler),
 	}
-	s.CreateFileSubscriber(f)
-	return s
 }

--- a/subscribe/file.go
+++ b/subscribe/file.go
@@ -1,0 +1,66 @@
+package subscribe
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/davinche/godown/markdown"
+	"github.com/russross/blackfriday"
+	"golang.org/x/net/websocket"
+)
+
+// ----------------------------------------------------------------------------
+// Utility
+// ----------------------------------------------------------------------------
+func getRenderedFromFile(file string) (string, error) {
+	fileStr, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	return string(blackfriday.MarkdownCommon(fileStr)), nil
+}
+
+// NewFile creates a new file changes writer
+func NewFile(f *markdown.File) *File {
+	return &File{
+		file: f,
+		ConnHandler: ConnHandler{
+			clients: make(map[*websocket.Conn]struct{}),
+		},
+	}
+}
+
+// File tracks all subscribers to a file and writes the new changes to them
+// on file change
+type File struct {
+	file *markdown.File
+	ConnHandler
+}
+
+// Broadcast sends all registered websockets with the updated file
+func (f *File) Broadcast() {
+	fileStr, err := getRenderedFromFile(f.file.Path)
+	if err != nil {
+		fmt.Printf("error reading file: %q", err)
+		return
+	}
+	renderFmt := RenderFormat{fileStr}
+	// loop and write
+	f.Lock()
+	defer f.Unlock()
+	for ws := range f.clients {
+		websocket.JSON.Send(ws, renderFmt)
+	}
+}
+
+// Add tracks a websocket connection against a watched file
+func (f *File) Add(ws *websocket.Conn) {
+	f.ConnHandler.Add(ws)
+	fileStr, err := getRenderedFromFile(f.file.Path)
+	if err != nil {
+		fmt.Printf("error reading file: %q", err)
+		return
+	}
+	renderFmt := RenderFormat{fileStr}
+	websocket.JSON.Send(ws, renderFmt)
+}

--- a/subscribe/interfaces.go
+++ b/subscribe/interfaces.go
@@ -1,0 +1,44 @@
+package subscribe
+
+import (
+	"sync"
+
+	"golang.org/x/net/websocket"
+)
+
+// Handler is the interface for a weboscket subscriber
+type Handler interface {
+	Broadcast()
+	Add(ws *websocket.Conn)
+	Del(ws *websocket.Conn)
+}
+
+// Source is where the struct that the server uses to identify the markdown resource
+type Source interface {
+	GetID() string
+}
+
+// ConnHandler tracks websocket connections
+type ConnHandler struct {
+	clients map[*websocket.Conn]struct{}
+	sync.Mutex
+}
+
+// Add tracks a websocket connection against a watched file
+func (c *ConnHandler) Add(ws *websocket.Conn) {
+	c.Lock()
+	defer c.Unlock()
+	c.clients[ws] = struct{}{}
+}
+
+// Del removes a websocket connection against a watched file
+func (c *ConnHandler) Del(ws *websocket.Conn) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.clients, ws)
+}
+
+// RenderFormat is the struct that holds the rendered markdown
+type RenderFormat struct {
+	Render string `json:"render"`
+}

--- a/subscribe/mem.go
+++ b/subscribe/mem.go
@@ -1,0 +1,43 @@
+package subscribe
+
+import (
+	"github.com/davinche/godown/memory"
+	"github.com/russross/blackfriday"
+	"golang.org/x/net/websocket"
+)
+
+// NewMem creates a new in memory changes tracker
+func NewMem(f *memory.File) *Mem {
+	return &Mem{
+		file: f,
+		ConnHandler: ConnHandler{
+			clients: make(map[*websocket.Conn]struct{}),
+		},
+	}
+}
+
+// Mem tracks all subscribers to an in-memory markdown file
+type Mem struct {
+	file *memory.File
+	ConnHandler
+}
+
+// Broadcast sends all subscribed websockets with new file changes
+func (m *Mem) Broadcast() {
+	rendered := string(blackfriday.MarkdownCommon(m.file.Content))
+	renderFmt := RenderFormat{rendered}
+	// loop and write
+	m.Lock()
+	defer m.Unlock()
+	for ws := range m.clients {
+		websocket.JSON.Send(ws, renderFmt)
+	}
+}
+
+// Add tracks a websocket connection against the in memory markdown
+func (m *Mem) Add(ws *websocket.Conn) {
+	m.ConnHandler.Add(ws)
+	rendered := string(blackfriday.MarkdownCommon(m.file.Content))
+	renderFmt := RenderFormat{rendered}
+	websocket.JSON.Send(ws, renderFmt)
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -71,14 +71,14 @@ func NewWatchMonitor() *WatchMonitor {
 func (w *WatchMonitor) AddWatcher(f *markdown.File) {
 	w.Lock()
 	defer w.Unlock()
-	if w.watchers[f.ID] != nil {
+	if w.watchers[f.GetID()] != nil {
 		return
 	}
 	watcher := &watchFile{
 		file: f,
 		done: make(chan struct{}),
 	}
-	w.watchers[f.ID] = watcher
+	w.watchers[f.GetID()] = watcher
 	go watcher.Start(w.changes)
 }
 


### PR DESCRIPTION
Markdown data can now be sent to the daemon to be rendered.
    - Example usage: godown send myIdentifier "# Hello World"

Added the "-l" flag to specify whether to open the browser on "start"
and "send" commands.
